### PR TITLE
Derive damaged status from wear value

### DIFF
--- a/MWCeditor/mwce.ini
+++ b/MWCeditor/mwce.ini
@@ -218,9 +218,8 @@
 // ==========================================~-
 
 #"Report_Identifiers"
-"bolted" // bolted , a bool where Im not sure how it works, but its probably important. 
 "blt" // bolts , a stringlist keeping track of all bolt states on a part. Only exists when the part has bolts, and is installed
-"damaged" //damaged , a bool saving the damage state of a part
+"wea" // wear , a float (0-100) representing part wear. Values below 5 are considered damaged
 "aid" //assembly id, stored as an integer, used by the tool to identify a carpart
 "tgh" //tightness , a float that is the sum of all bolt states on a part. Only exists when the part has bolts
 "corner" //carcorner where wheel is installed , empty string when not installed, otherwise its FR/FL/RR/RL

--- a/MWCeditor/structs.h
+++ b/MWCeditor/structs.h
@@ -66,7 +66,6 @@ struct CarPart
 	uint32_t iInstalled = UINT_MAX;
 	uint32_t iBolts = UINT_MAX;
 	uint32_t iTightness = UINT_MAX;
-	uint32_t iBolted = UINT_MAX;
 	uint32_t iDamaged = UINT_MAX;
 	uint32_t iCorner = UINT_MAX;
 };


### PR DESCRIPTION
## Summary
- replace the damaged part identifier with wear to align with save data
- compute part damage from wear values below 5 and display that status in the bolt list
- repair damage by restoring wear to 100 instead of toggling a missing damaged flag

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f3aea7fc83318f217e154c2f678e)