### PR TITLE
Handle valve list maintenance entries

### DIFF
--- a/MWCeditor/dlgprocs.cpp
+++ b/MWCeditor/dlgprocs.cpp
@@ -37,8 +37,6 @@ namespace
 constexpr size_t MinAidDigits = 1;
 constexpr size_t MaxAidDigits = 2;
 constexpr bool ValveListAlternatingLayout = false;
-constexpr size_t ValveDigitsMin = 1;
-constexpr size_t ValveDigitsMax = 2;
 
 enum class ValveType
 {
@@ -301,7 +299,7 @@ bool TryBindStringListProperty(CarProperty& property, const VariableLookupMap& v
 	{
 		for (const auto& entry : variableLookup)
 		{
-			if (!MatchMaintenancePattern(property.lookupname, entry.first, ValveDigitsMin, ValveDigitsMax, digits))
+			if (!MatchMaintenancePattern(property.lookupname, entry.first, MinAidDigits, MaxAidDigits, digits))
 				continue;
 
 			property.lookupname = entry.first;

--- a/MWCeditor/dlgprocs.cpp
+++ b/MWCeditor/dlgprocs.cpp
@@ -77,6 +77,23 @@ bool ParseValveValue(const std::wstring& text, float& outValue)
 	return endPtr != trimmed.c_str();
 }
 
+std::wstring FormatValveValueForDisplay(const std::wstring& raw)
+{
+	float value = 0.0f;
+	if (!ParseValveValue(raw, value))
+		return raw;
+
+	std::wstring text = std::to_wstring(value);
+	return *TruncFloatStr(text);
+}
+
+std::wstring FormatValveValueForStorage(float value)
+{
+	std::wstring text = std::to_wstring(value);
+	TruncFloatStr(text);
+	return L"float(" + text + L")";
+}
+
 std::vector<std::wstring> DecodeStringList(const Variable& variable)
 {
 	std::vector<std::wstring> values;
@@ -151,7 +168,7 @@ std::wstring GetValveDisplayValue(const CarProperty& property)
 	if (property.elementIndex >= values.size())
 		return L"";
 
-	return values[property.elementIndex];
+	return FormatValveValueForDisplay(values[property.elementIndex]);
 }
 
 bool MatchMaintenancePattern(const std::wstring& pattern, const std::wstring& key, size_t minDigits, size_t maxDigits, std::wstring& outDigits)
@@ -690,7 +707,16 @@ void UpdateRow(HWND hwnd, uint32_t pIndex, int nRow, std::wstring str = L"")
 			if (sValue.empty())
 				sValue = values[carproperties[pIndex].elementIndex];
 
-			values[carproperties[pIndex].elementIndex] = sValue;
+			float valveValue = 0.0f;
+			if (ParseValveValue(sValue, valveValue))
+			{
+				values[carproperties[pIndex].elementIndex] = FormatValveValueForStorage(valveValue);
+				sValue = FormatValveValueForDisplay(values[carproperties[pIndex].elementIndex]);
+			}
+			else
+			{
+				values[carproperties[pIndex].elementIndex] = sValue;
+			}
 			binValue = EncodeStringList(values);
 			UpdateValue(L"", carproperties[pIndex].index, binValue);
 		}

--- a/MWCeditor/dlgprocs.cpp
+++ b/MWCeditor/dlgprocs.cpp
@@ -1353,7 +1353,7 @@ INT_PTR CALLBACK PropertyListProc(HWND hwnd, uint32_t Message, WPARAM wParam, LP
 			StaticRekt.right -= 2 + StaticRekt.left;
 
 			// Fetch the value and create edit-box
-			std::wstring vStr = variables[carproperties[pIndex].index].GetDisplayString();
+			std::wstring vStr = carproperties[pIndex].elementIndex == UINT_MAX ? variables[carproperties[pIndex].index].GetDisplayString() : GetValveDisplayValue(carproperties[pIndex]);
 			hEditValue = CreateWindowEx(WS_EX_CLIENTEDGE, WC_EDIT, vStr.c_str(), WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL, StaticRekt.left, StaticRekt.top, StaticRekt.right, StaticRekt.bottom, hwnd, (HMENU)IDC_PLEDIT, hInst, NULL);
 			SendMessage(hEditValue, WM_SETFONT, (WPARAM)hListFont, TRUE);
 			SendMessage(hEditValue, EM_SETLIMITTEXT, 16, 0);

--- a/MWCeditor/mwce.ini
+++ b/MWCeditor/mwce.ini
@@ -282,7 +282,7 @@
 //"Cylinder exhaust 2"				"rockershaftcyl2exhaust"			"2"		"6.75"		"8"			"7"
 //"Cylinder exhaust 3"				"rockershaftcyl3exhaust"			"2"		"6.75"		"8"			"7"
 //"Cylinder exhaust 4"				"rockershaftcyl4exhaust"			"2"		"6.75"		"8"			"7"
-"Valve lash"					"vin1110vlv"						"8"		""			""			"5"
+"Valve lash"					"vin111*vlv"						"8"		""			""			"5"
 "Stock carburator A/F ratio"	"vin113*dt1"						"2"		"10"		"16.75"		"14.7"			// no idea if A/F is the same as in og game
 "Twin carburators A/F ratio"	"carb2brla0*dt1"					"2"		"10"		"16.75"		"14.7"
 "Racing carburator A/F ratio 1"	"carb4brla0*dt1"					"2"		"10"		"21"		"14.9"

--- a/MWCeditor/mwce.ini
+++ b/MWCeditor/mwce.ini
@@ -282,7 +282,7 @@
 //"Cylinder exhaust 2"				"rockershaftcyl2exhaust"			"2"		"6.75"		"8"			"7"
 //"Cylinder exhaust 3"				"rockershaftcyl3exhaust"			"2"		"6.75"		"8"			"7"
 //"Cylinder exhaust 4"				"rockershaftcyl4exhaust"			"2"		"6.75"		"8"			"7"
-"Valve lash"					"vin111*vlv"						"8"		""			""			"5"
+"Valve lash"					"vin111*vlv"						"8"		"0"			"10"			"5"			// placeholder limits
 "Stock carburator A/F ratio"	"vin113*dt1"						"2"		"10"		"16.75"		"14.7"			// no idea if A/F is the same as in og game
 "Twin carburators A/F ratio"	"carb2brla0*dt1"					"2"		"10"		"16.75"		"14.7"
 "Racing carburator A/F ratio 1"	"carb4brla0*dt1"					"2"		"10"		"21"		"14.9"
@@ -356,7 +356,6 @@
 "use_euler" "0"
 "raw_names" "1"
 "check_issues" "0"
-
 // ==========================================~-
 // Optional grouping aliases
 // Use this to override how entries are grouped and displayed in the left list.
@@ -475,5 +474,6 @@
 "aircleaner" "aircleaner2"
 "spring"     "spring2"
 "extclamp"   "extclamp"
+"wiring"	 "wiring"
 "14`wheel"   "14`wheel"
 "15`wheel"   "15`wheel"

--- a/MWCeditor/mwce.ini
+++ b/MWCeditor/mwce.ini
@@ -256,7 +256,9 @@
 // "Display name" "name" "data type" "min" "max" "suggestion"
 // datatypes: 
 // ID_FLOAT			2
+// ID_INT			6
 // ID_VECTOR		7
+// ID_STRINGLIST	8
 // ==========================================~-
 
 #"Report_Maintenance"
@@ -280,6 +282,7 @@
 //"Cylinder exhaust 2"				"rockershaftcyl2exhaust"			"2"		"6.75"		"8"			"7"
 //"Cylinder exhaust 3"				"rockershaftcyl3exhaust"			"2"		"6.75"		"8"			"7"
 //"Cylinder exhaust 4"				"rockershaftcyl4exhaust"			"2"		"6.75"		"8"			"7"
+"Valve lash"					"vin1110vlv"						"8"		""			""			"5"
 "Stock carburator A/F ratio"	"vin113*dt1"						"2"		"10"		"16.75"		"14.7"			// no idea if A/F is the same as in og game
 "Twin carburators A/F ratio"	"carb2brla0*dt1"					"2"		"10"		"16.75"		"14.7"
 "Racing carburator A/F ratio 1"	"carb4brla0*dt1"					"2"		"10"		"21"		"14.9"
@@ -288,9 +291,9 @@
 "Racing carburator A/F ratio 4"	"carb4brla0*dt4"					"2"		"10"		"21"		"14.9"
 //"Final gear ratio"				"gearboxfinalgearratio"				"2"		""			"3.7"					// cant find the new entry
 "AT Transmission oil level"		"vin136*dt2"						"2"		"0"			"5.3"
-"Transmission damage"			"vin136*dt1"						"2"		"100"		"0"		
-"Transmission damage"			"vin124*dt1"						"2"		"100"		"0"
-"Transmission damage"			"gearbox5spd*dt1"					"2"		"100"		"0"
+"Transmission damage"			"vin136*dt1"						"6"		"100"		"0"		
+"Transmission damage"			"vin124*dt1"						"6"		"100"		"0"
+"Transmission damage"			"gearbox5spd*dt1"					"6"		"100"		"0"
 "Distributor spark timing"		"vin131*dt1"						"2"		"12"		"15"		"14.5"
 "Fanbelt tightness"				"vin133*dat"						"2"		"0"			"7"			"0.5"
 "Fanbelt tightness"				"alternator0*dat"					"2"		"0"			"7"			"0.5"

--- a/MWCeditor/structs.h
+++ b/MWCeditor/structs.h
@@ -3,6 +3,12 @@
 #include <string> 
 #include <tchar.h> 
 #include <algorithm> 
+#include <limits>
+
+constexpr uint32_t MaintenanceDataType_Float = 2;
+constexpr uint32_t MaintenanceDataType_Int = 6;
+constexpr uint32_t MaintenanceDataType_Vector = 7;
+constexpr uint32_t MaintenanceDataType_StringList = 8;
 
 struct QTRN
 {
@@ -79,14 +85,16 @@ struct CarProperty
 	std::string recommendedBin;
 	uint32_t datatype;
 	uint32_t index;
+	float recommendedValue = std::numeric_limits<float>::quiet_NaN();
+	uint32_t elementIndex = UINT_MAX;
 
 	CarProperty() 
 	{
 	
 	}
 
-	CarProperty(std::wstring displayname_, std::wstring lookupname_, uint32_t datatype_, std::string worst_, std::string optimum_, std::string recommended_ = "", uint32_t index_ = UINT_MAX)
-		: displayname(std::move(displayname_)), lookupname(std::move(lookupname_)), datatype(std::move(datatype_)), worstBin(std::move(worst_)), optimumBin(std::move(optimum_)), recommendedBin(std::move(recommended_)), index(std::move(index_))
+	CarProperty(std::wstring displayname_, std::wstring lookupname_, uint32_t datatype_, std::string worst_, std::string optimum_, std::string recommended_ = "", uint32_t index_ = UINT_MAX, float recommendedValue_ = std::numeric_limits<float>::quiet_NaN(), uint32_t elementIndex_ = UINT_MAX)
+		: displayname(std::move(displayname_)), lookupname(std::move(lookupname_)), datatype(std::move(datatype_)), worstBin(std::move(worst_)), optimumBin(std::move(optimum_)), recommendedBin(std::move(recommended_)), index(std::move(index_)), recommendedValue(std::move(recommendedValue_)), elementIndex(std::move(elementIndex_))
 	{
 
 	}

--- a/MWCeditor/utils.cpp
+++ b/MWCeditor/utils.cpp
@@ -14,6 +14,7 @@
 #include <iostream> // Console
 #include <set>
 #include <array>
+#include <limits>
 #include <windows.h>
 #include <cstdio>
 
@@ -841,11 +842,17 @@ void FillVector(const std::vector<std::wstring> &params, const std::wstring &ide
 		auto datatype = static_cast<uint32_t>(::strtol(NarrowStr(params[2]).c_str(), NULL, 10));
 		std::string worst = !params[3].empty() ? Variable::ValueStrToBin(params[3], datatype) : "";
 		std::string optimum = !params[4].empty() ? Variable::ValueStrToBin(params[4], datatype) : "";
+		float recommendedValue = std::numeric_limits<float>::quiet_NaN();
+		if (params.size() == 6 && !params[5].empty())
+			recommendedValue = static_cast<float>(::wcstod(params[5].c_str(), NULL));
 
 		if (params.size() == 5)
-			carproperties.push_back(CarProperty(params[0], params[1], datatype, worst, optimum));
+			carproperties.push_back(CarProperty(params[0], params[1], datatype, worst, optimum, "", UINT_MAX, recommendedValue));
 		else if (params.size() == 6)
-			carproperties.push_back(CarProperty(params[0], params[1], datatype, worst, optimum, Variable::ValueStrToBin(params[5], datatype)));
+		{
+			auto recommendedBin = datatype == MaintenanceDataType_StringList ? std::string() : Variable::ValueStrToBin(params[5], datatype);
+			carproperties.push_back(CarProperty(params[0], params[1], datatype, worst, optimum, recommendedBin, UINT_MAX, recommendedValue));
+		}
 	}
 	else if (identifier == L"Event_Timetable")
 	{


### PR DESCRIPTION
## Summary
- add maintenance datatype constants and capture numeric recommendations to support new maintenance categories
- expand maintenance UI to decode list-based valve lash entries and offer per-cylinder fix actions
- update Report_Maintenance configuration to mark transmission damage as integers and register the valve lash list entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c34728670833192e5f5926cc79e05)