### PR TITLE
Avoid overwriting wiring tightness on install

### DIFF
--- a/MWCeditor/utils.cpp
+++ b/MWCeditor/utils.cpp
@@ -401,9 +401,28 @@ bool IsAidInstalled(const Variable& variable)
 	return GetAidValue(variable.value) >= 1;
 }
 
+static bool HasAidIdentifierKey(const CarPart& part)
+{
+	if (part.iInstalled == UINT_MAX || part.iInstalled >= variables.size())
+		return FALSE;
+
+	if (partIdentifiers.size() <= 2 || partIdentifiers[2].empty())
+		return FALSE;
+
+	const auto& key = variables[part.iInstalled].key;
+	const auto& identifier = partIdentifiers[2];
+	if (key.size() < identifier.size())
+		return FALSE;
+
+	return key.compare(key.size() - identifier.size(), identifier.size(), identifier) == 0;
+}
+
 bool IsPartInstalled(const CarPart& part)
 {
 	if (part.iInstalled == UINT_MAX || part.iInstalled >= variables.size())
+		return FALSE;
+
+	if (!HasAidIdentifierKey(part))
 		return FALSE;
 
 	return IsAidInstalled(variables[part.iInstalled]);
@@ -2711,9 +2730,10 @@ void BatchProcessWiring() //2012
 	{
 		if (StartsWithStr(carparts[i].name, WiringIdentifier))
 		{
-			const bool installed = IsPartInstalled(carparts[i]);
+			const bool hasAidKey = HasAidIdentifierKey(carparts[i]);
+			const bool installed = hasAidKey && IsPartInstalled(carparts[i]);
 
-			if (carparts[i].iInstalled != UINT_MAX && !installed)
+			if (hasAidKey && !installed)
 			{
 				UpdateValue(L"1", carparts[i].iInstalled);
 				InstalledParts.push_back(i);


### PR DESCRIPTION
### Motivation
- Prevent wiring install logic from overwriting existing wiring tightness/TGH values when parts lack the expected AID identifier.
- Ensure `fix loose bolts` behavior still tightens wiring bolts (including `wiringTGH` and `BLT` entries) even if install flags are not written. 
- Make `IsPartInstalled` more robust by validating the variable key matches the configured part identifier. 

### Description
- Added helper `HasAidIdentifierKey(const CarPart&)` to verify the installed-variable key ends with the configured AID identifier. 
- Updated `IsPartInstalled` to return false when the AID identifier key check fails. 
- Changed `BatchProcessWiring` to only write `iInstalled` when `HasAidIdentifierKey` is true, while preserving bolt/tightness updates for wiring parts. 
- Minor refactor to centralize the identifier check and avoid duplicating string-compare logic. 

### Testing
- No automated tests were executed for this change. 
- Changes were committed after local edits (no CI or unit test runs were invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9d5dd2448331b70cdb0a09396231)