### PR TITLE
Store Linux last save directory in config file and prefer it for Open dialog

### DIFF
--- a/MWCeditor/externs.cpp
+++ b/MWCeditor/externs.cpp
@@ -21,6 +21,7 @@ std::map<std::wstring, GroupingAlias> groupingAliases;							// Grouping aliases
 std::wstring filepath;															// Full file path of currently opened file
 std::wstring filename;															// Filename of currently opened file
 std::wstring appfolderpath;														// Path to the writable apps folder
+std::wstring lastSaveDirectory;													// Last known save directory
 HANDLE hTempFile = INVALID_HANDLE_VALUE;										// Handle of the tempfile. Invalidated upon exiting
 SYSTEMTIME filedate;
 HFONT hListFont;
@@ -30,7 +31,7 @@ class MapDialog* EditorMap = NULL;
 #endif /*_MAP*/
 
 bool bFiledateinit = FALSE, bMakeBackup = TRUE, bEulerAngles = FALSE, bBackupChangeNotified = FALSE, bFirstStartup = TRUE, bAllowScale = FALSE, bDisplayRawNames = FALSE, bCheckIssues = FALSE, bStartWithMap = FALSE;
-const std::wstring settings[] = { L"make_backup", L"backup_change_notified", L"first_startup", L"allow_scale", L"use_euler", L"raw_names", L"check_issues", L"start_with_map"};
+const std::wstring settings[] = { L"make_backup", L"backup_change_notified", L"first_startup", L"allow_scale", L"use_euler", L"raw_names", L"check_issues", L"start_with_map", L"last_save_directory"};
 PVOID pResizeState = NULL;
 
 const float kindasmall = 1.0e-4f;
@@ -99,7 +100,7 @@ const std::wstring GLOB_STRS[] =
 	L"Hey buddy! Looks like you're new.", //42
 	L"\nUnexpected EOF!", //43
 	L"You are about to open a backup file. Is this intentional?", //44
-	L"\nClick a value to modify it, then press Set to apply the change or Fix to restore a recommended value.\n\nProgrammer’s note:\nMost values shown here are taken directly from in-game data and were added quickly to make the editor usable. The suggested values are not definitive meta values, as many are inherited from the original game or are only rough references.\n\nAt this point, the actual meta tuning values still need to be discovered by players.\n\nSome condition values may be set to 99 or 11 on purpose\n'FIX' values are NOT whats best and are guesses for now!\n\nFor best results, tune the car in-game whenever possible.\nHave fun!", //45
+	L"\nClick a value to modify it, then press Set to apply the change or Fix to restore a recommended value.\n\nProgrammerâ€™s note:\nMost values shown here are taken directly from in-game data and were added quickly to make the editor usable. The suggested values are not definitive meta values, as many are inherited from the original game or are only rough references.\n\nAt this point, the actual meta tuning values still need to be discovered by players.\n\nSome condition values may be set to 99 or 11 on purpose\n'FIX' values are NOT whats best and are guesses for now!\n\nFor best results, tune the car in-game whenever possible.\nHave fun!", //45
 	//L"\nClick a value to modify, then press set to apply the change or press fix to set it to a recommended value.\n\n\nProgrammers Notes:\nThe values for tuning parts are just my suggestions.\nFor instance, the suggested air/fuel ratio of 14:7 is the stoichiometric mixture that provides the best balance between power and fuel economy. To further decrease fuel consumption, you could make the mixture even leaner. For maximum power, you could set it to something like 13.1. \n\nThe same applies to the spark timing on the distributor. There is no best value for this, as with a racing carburator with N2O, the timing needs to be much higher (~13) than with the twin or stock carburator (~14.8).\n\nThe final gear ratio should be between 3.7 - 4.625. Lower values provide higher top speed but less acceleration.\n\n\nI highly recommend tuning it in the game though, as this is what the game is about ;)\nHave fun!", //45
 	L"Could not complete action.\n", //46
 	L"Could not find item ID entry!\n", //47

--- a/MWCeditor/externs.h
+++ b/MWCeditor/externs.h
@@ -85,6 +85,7 @@ extern std::map<std::wstring, GroupingAlias> groupingAliases;
 extern std::wstring filepath;
 extern std::wstring filename;
 extern std::wstring appfolderpath;
+extern std::wstring lastSaveDirectory;
 extern HANDLE hTempFile;
 extern SYSTEMTIME filedate;
 extern HFONT hListFont;


### PR DESCRIPTION
### Motivation

- Make the app more Linux/Wine friendly by persisting the last-used save folder to a Linux-native config location instead of relying on `mwce.ini` on Linux builds.
- Prefer a sensible default save folder under Linux/Proton (Wine prefix Steam path) when opening files so users don't have to navigate into Wine prefixes manually.
- Avoid changing Windows behavior; keep existing `mwce.ini` persistence for non-Linux builds via `#ifndef LINUX` guards.

### Description

- Add a new global `lastSaveDirectory` and update `externs.h`/`externs.cpp` to expose it via `extern` and include it in the `settings` list for Windows builds.
- Add helpers `DirectoryExists` and `TrySetDefaultFolder` and Linux-only helpers `GetLinuxUserHomePath`, `GetLinuxConfigDirectory`, `EnsureLinuxConfigDirectoryExists`, `LoadLastSaveDirectoryFromFile`, and `StoreLastSaveDirectoryToFile` in `MWCeditor/utils.cpp` to manage a `~/.config/mwceditor/last_save_dir.txt` file.
- Update `OpenFileDialog` to: load `lastSaveDirectory` from the Linux config file when `LINUX` is defined, prefer `lastSaveDirectory` for the dialog default, fall back to the Linux/Proton game save path, and then fall back to the original Windows `LocalAppDataLow` path; and store the selected folder back to the Linux config file on selection.
- Keep settings parsing/saving of `lastSaveDirectory` in `mwce.ini` behind `#ifndef LINUX` so Windows behavior is unchanged and Linux uses the file-based config.

### Testing

- No automated tests were run.
- No build or CI runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695feebaa1ac8331bb4ba4e657c48bbc)